### PR TITLE
feat: Conditionally render Dashboard tables and adjust layout

### DIFF
--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -6,6 +6,11 @@ import TimelineVisualization from '../components/TimelineVisualization';
 import AggregationsTable from '../components/AggregationsTable';
 
 const Dashboard = () => {
+  const { results, aggregations } = useSelector(state => state.query);
+
+  const shouldShowResults = results && results.length > 0;
+  const shouldShowAggregations = aggregations && Object.keys(aggregations).length > 0;
+
   return (
     <div className="w-full">
       <div className="pb-5 border-b border-gray-200">
@@ -18,12 +23,21 @@ const Dashboard = () => {
         <TimelineVisualization />
         
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          <div className="lg:col-span-1">
-            <ResultsTable />
-          </div>
-          <div className="lg:col-span-1">
-            <AggregationsTable />
-          </div>
+          {shouldShowResults && (
+            <div className={shouldShowAggregations ? "lg:col-span-1" : "lg:col-span-2"}>
+              <ResultsTable />
+            </div>
+          )}
+          {shouldShowAggregations && (
+            <div className={shouldShowResults ? "lg:col-span-1" : "lg:col-span-2"}>
+              <AggregationsTable />
+            </div>
+          )}
+          {!shouldShowResults && !shouldShowAggregations && (
+            <div className="lg:col-span-2 bg-white shadow rounded-lg p-6 text-center">
+              <p className="text-gray-500">No data to display. Try executing a query.</p>
+            </div>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Modified Dashboard.js to:
- Fetch results and aggregations from the Redux store.
- Render ResultsTable only when query results are available.
- Render AggregationsTable only when aggregation data is available.
- Adjust the layout dynamically:
    - If both tables are present, they are displayed in a two-column grid.
    - If only one table is present, it spans the full width of the grid.
    - If no data is available for either table, a "No data to display" message is shown.

This change improves your experience by only showing relevant data components and providing clear feedback when no data is present.